### PR TITLE
Don't crash if socket has been closed

### DIFF
--- a/DataWedge-WebSockets-Bridge/app/src/main/java/com/darryncampbell/datawedge_websockets_bridge/MySocketServer.java
+++ b/DataWedge-WebSockets-Bridge/app/src/main/java/com/darryncampbell/datawedge_websockets_bridge/MySocketServer.java
@@ -39,6 +39,7 @@ public class MySocketServer extends WebSocketServer {
     @Override
     public void onClose(WebSocket conn, int code, String reason, boolean remote) {
         Log.i(TAG, "onClose");
+        mSocket = null;
     }
 
     @Override


### PR DESCRIPTION
Right now, if a client's WS connects to the bridge, closes the connection, and then a code is scanned, the bridge crashes as it tries to send a message to a closed socket.
This change fixes it by unsetting the WS on close.
